### PR TITLE
Fix requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-requests
+--index-url https://pypi.python.org/simple/
+
+-e .

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,8 @@
 import sys
 import os
 from setuptools import setup
-from pip.req import parse_requirements
 from setuptools.command.install import install
 
-install_requires = parse_requirements(os.path.join(os.path.split(__file__)[0], "requirements.txt"))
-install_requires = [str(ir.req) for ir in install_requires]
 
 class my_install(install):
     def run(self):
@@ -21,7 +18,9 @@ s = setup(
     description='Command line interface for OctoPrint',
     keywords=['OctoPrint', 'command'],
     scripts=["scripts/octocmd"],
-    install_requires=install_requires,
+    install_requires=[
+        "requests",
+    ],
     packages=None,
     cmdclass={'install': my_install}
 )


### PR DESCRIPTION
The api for `pip.req.parse_requirements` is undocumented and has changed in version 6, which leads to the following error:

```
TypeError: parse_requirements() missing 1 required keyword argument: 'session'
```

Instead we will use the [method][1] suggested by pip maintainer Donald Stufft.

[1]: https://caremad.io/2013/07/setup-vs-requirement/